### PR TITLE
Add defensive check to workaround obscure bug with nil parent

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -551,6 +551,13 @@ func (s wStmt) Close() (err error) {
 }
 
 func (s wStmt) NumInput() int {
+	// NumInput may also return -1, if the driver doesn't know
+	// its number of placeholders. In that case, the sql package
+	// will not sanity check Exec or Query argument counts.
+	if s.parent == nil {
+		return -1
+	}
+
 	return s.parent.NumInput()
 }
 


### PR DESCRIPTION
Under unclear circumstances `NumInput` fails with a nil pointer panic, this happens rarely and is hard to reproduce.

This PR adds a nil check and a fallback to safe behavior as a workaround.